### PR TITLE
Adding a state flag to UserModule

### DIFF
--- a/include/app-framework-base/UserModules/UserModule.hh
+++ b/include/app-framework-base/UserModules/UserModule.hh
@@ -18,6 +18,8 @@
 #include <string>
 #include <future>
 
+#include "app-framework-base/UserModules/UserModuleState.hh"
+
 namespace appframework {
 /**
  * @brief The UserModule class is a set of code which performs a specific task.
@@ -38,6 +40,13 @@ class UserModule {
      * this result.
      */
     virtual std::future<std::string> execute_command(std::string cmd) = 0;
+
+    UserModuleState State() const noexcept { return fState.load() ; }
+
+  protected:
+    std::atomic<UserModuleState> fState = UserModuleState::kUnknown ;
+  
+
 };
 }  // namespace appframework
 

--- a/include/app-framework-base/UserModules/UserModuleState.hh
+++ b/include/app-framework-base/UserModules/UserModuleState.hh
@@ -1,0 +1,31 @@
+/**
+ * @file UserModuleState enum classss Interface
+ *
+ * These are the possible states in which a UserModule can be found. 
+ * These states are orthogonal to the states or transitions defined by CCM. 
+ * UserModeuleStates are a way for whatever controls and owns the module to know what is going on in the threads managed by the module.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have received with this code.
+ */
+
+#ifndef app_framework_base_UserModules_UserModuleState_hh
+#define app_framework_base_UserModules_UserModuleState_hh
+
+
+namespace appframework {
+/**
+ * @brief The UserModuleState class an enum 
+ *
+ * These states should report the status of the internal Module's threads from outside
+ * 
+ */
+enum struct UserModuleState : int16_t {
+    kError = -1 , 
+    kUnknown = 0 ,
+    kOk
+};
+
+}  // namespace appframework
+
+#endif  // app_framework_base_UserModules_UserModuleState_hh


### PR DESCRIPTION
UserModules have now a status that can indicates errors, etc. possible states can be extended. We need to decide what is checking on these state periodically. 