### PR TITLE
Fix missing include directory

### DIFF
--- a/unittest/UserModules/CMakeLists.txt
+++ b/unittest/UserModules/CMakeLists.txt
@@ -2,6 +2,6 @@
 add_executable(UserModuleThreadHelper_test UserModuleThreadHelper_test.cc)
 target_link_libraries(UserModuleThreadHelper_test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} pthread)
 target_compile_definitions(UserModuleThreadHelper_test PRIVATE "BOOST_TEST_DYN_LINK=1")
-target_include_directories(UserModuleThreadHelper_test PRIVATE ${Boost_INCLUDE_DIRS})
+target_include_directories(UserModuleThreadHelper_test PRIVATE ${Boost_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/app-framework-base/include)
 add_test(NAME UserModuleThreadHelper_test COMMAND UserModuleThreadHelper_test)
 


### PR DESCRIPTION
Simple fix to make sure that develop builds while the renaming branch is still in progress.